### PR TITLE
Align the help of instance status

### DIFF
--- a/text/1006-simplified-cli.rst
+++ b/text/1006-simplified-cli.rst
@@ -104,7 +104,7 @@ the EdgeDB RC1 release::
     server list-versions       List available and installed versions of the server
 
     instance create            Initialize a new server instance
-    instance status            Show statuses of available instances
+    instance status            Show statuses of all or of a matching instance
     instance start             Start an instance
     instance stop              Stop an instance
     instance restart           Restart an instance


### PR DESCRIPTION
The [previous diff](https://github.com/edgedb/rfcs/pull/38/files#diff-845ef67ec7915b3cf1595ebf23e3ad74f905daba9b81036890b28a5f34fd0857L100) of this help message in RFC was not based on [the latest CLI help message](https://github.com/edgedb/edgedb-cli/issues/355).